### PR TITLE
Clear, concise, and aspirational XX-1 policies

### DIFF
--- a/AC-Policy.md
+++ b/AC-Policy.md
@@ -9,7 +9,7 @@ See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId
 
 ## Purpose
 
-Limit information system access to authorized users or processes acting on behalf of authorized users. The policy also limits the types of actions authorized users are permitted to exercise.
+Limit information system access to authorized users or processes acting on behalf of authorized users. Enforce "least privilege" methodologies for all system actions.
 
 ## Scope
 
@@ -17,4 +17,6 @@ See the **_Applicability_** section of the [GSA IT Security Policy](http://www.g
 
 ## Policy overlay
 
-For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Services's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
+
+## Procedures

--- a/AT-Policy.md
+++ b/AT-Policy.md
@@ -1,43 +1,27 @@
-# 18F Security Awareness and Training Policy
+# Security awareness and training policy
 
-## 1. Purpose of Policy
-The purpose of this policy is to provide governance for:
-* Ongoing security education and training for 18F personnel
-* Associated security awareness and training controls
-* Formal, documented procedures to facilitate security awareness and training.
-* Maintaining currency with recommended security practices, techniques, and technologies
-* Sharing current security-related information including threats, vulnerabilities, and incidents.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 4, _Policy on Operational Controls_, which covers:
 
-The 18F program includes a library of policies that address federal and commercial requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+* Awareness and Training (AT)
+* Configuration Management (CM)
+* Contingency Planning (CP)
+* Incident Response (IR)
+* Maintenance (MA)
+* Media Protection (MP)
+* Physical and Environmental Protection (PE)
+* Personnel Security (PS)
+* System and Information Integrity (SI)
 
-This policy is written to include the following:
-* Security Awareness Training
-* Role-Based Security Training
-* Security Training Records
+## Purpose
 
-## 2. Scope of Policy
-This policy is applicable to all 18F employees, partners, contractors, customers and vendors who use 18F information systems. This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+Provide the highest quality training in modern security practices, ensure announcements regarding new risks to information systems circulate immediately, and facilitate collaboration across the Service to develop new technologies or methodologies to compensate risk. 
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+## Scope
 
-## 3. Policy
-### Security Awareness Training
-* 18F shall provide basic security awareness training to all information system users (including managers, senior executives, and contractors) as part of initial training for new users, when required by system changes, and at least annually thereafter.
-* The security awareness training must include information on recognizing and reporting potential indicators of insider threat.
-* The 18F awareness training program commences with a formal induction process designed to introduce the Acceptable Use Policy and expectations for all personnel before access to information or services is granted. All new employees are required to take and pass on-line quizzes based on the Acceptable Use Policy. The awareness program is consistent, updated and deployed for all employees at least once a year.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-### Role-Based Security Training
-* The organization provides role-based security training to information system users before authorizing access to the information system or performing assigned duties, when required by information system changes, and at least annually thereafter
- * shall design and apply physical protection guidelines and mechanisms for working in secure areas.
- * 18F shall document, maintain and make available operating procedures for all users who need them.
- * 18F shall implement detection, prevention, and recovery controls; including appropriate user awareness procedures; to protect against malicious code.
+## Policy overlay
 
-### Security Training Records
-* 18F shall document both basic and role-based security awareness training activities.
-* Individual security training records must be maintained for the entire term of employment and updated on an annual basis for refresher training as required.
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-## 4. Roles and Responsibilities
-|Roles                        |Responsibilities
-|-----------------------------|---------------------------------------------------------------|
-|Senior Director              | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance       | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/AU-Policy.md
+++ b/AU-Policy.md
@@ -1,92 +1,22 @@
-# 18F Audit and Accountability Management Policy
+# Audit and accountability management policy
 
-## 1. Purpose of Policy
-Audit and accountability applies to maintaining an accurate audit trail of events, which may be used to provide a historical record of events for applicable network devices, systems, and applications.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 5, _Policy on Technical Controls_, which covers:
 
-The purpose of this policy is to ensure that 18F establishes requirements for a comprehensive program for developing, implementing and maintaining relevant information to support the audit and accountability objectives and security posture of the organization.
+* Access Control (AC)
+* Audit and Accountability (AU)
+* Identification and Authentication (IA)
+* System and Communications Protection (SC)
 
-The 18F program includes a library of policies that address federal and commercial requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+## Purpose
 
-This policy is written to include the following:
-*	Auditable Events
-*	Content of Audit Records
-*	Audit Storage Capacity
-*	Response To Audit Processing
-*	Audit Review, Analysis, and Reporting
-*	Audit Reduction and Report Generation
-*	Time Stamps
-*	Protection of Audit Records
-*	Audit Records Retention
-*	Audit Generation
+Ensure all actions taken on the information system are transparent, valid, and prevent repudiation. 
 
-## 2. Scope of Policy
-This policy applies to all network devices and servers used to process, store, or transmit data at 18F, and the Security infrastructure and processes used to manage and audit data. This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+## Scope
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+## Policy overlay
 
-### Auditable Events
-* 18F defines the list of events the information system must be capable of auditing based on a risk assessment and mission/business needs
-* 18F coordinates the security audit function with other organizational entities requiring audit-related information to enhance mutual support and help guide the selection of auditable events.
-* Security Engineering will be responsible for researching and working with cross-functional teams to implement a centrally managed framework with the capability of collecting information from integrated target sources and indexing data in a centralized location. This framework will provide reasonable control as to prevent rotation or manipulation of the collected log data 18F will provide a rationale for why the list of auditable events are deemed to be adequate to support after-the-fact investigations of security incidents
-* 18F information systems provide the capability to compile audit records from multiple components throughout the system into a system wide, time-correlated audit trail.
-* 18F information systems provide the capability to manage the selection of events to be audited by individual components of the system.
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-### Content of Audit Records
-* 18F information systems must capture sufficient information in audit records to establish what events occurred, the sources of the events and the outcomes of the events.
-* Audit record content includes, for most audit records:
- * Access Events
- * Systems and Account Administration Activity
- * Service and Process Starts and Stops
- * Network Traffic Permitted and Denied
- * Suspicious or Malicious Activities or Traffic
- * Physical Access Events
- * Account creation, modification, disabling, and termination actions
-
-### Execution of privileged functions
-* All 18F information systems provide the capability to include additional, more detailed information in the audit records for audit events identified by type, location or subject.
-* All 18F information systems provide the capability to manage the content of audit records generated by individual components throughout the system.
-
-### Audit Storage Capacity
-* 18F ensures the allocation of sufficient audit record storage capacity and configures auditing to prevent such capacity being exceeded.
-
-### Audit Processing
-* 18F will ensure automated mechanisms are in place to alert the appropriate personnel in the event of an audit failure or audit storage capacity being reached.
-* 18F information systems must provide a warning when allocated audit record storage volume reaches critical level as defined based on organization requirements (e.g. if the system reaches within 10% of allocated storage).
-
-### Audit Monitoring, Analysis and Reporting
-* 18F establishes processes for regularly reviewing audit log information, and reporting security issues if discovered. * Reviews will occur at a minimum of weekly. These processes should be integrated with processes for incident response, in order to ensure standardization and cross-functional collaboration
-* 18F employs automated mechanisms to integrate audit monitoring, analysis and reporting into an overall process for investigation and response to suspicious activities.
-* 18F employs automated mechanisms to immediately alert security personnel of inappropriate or unusual activities that have security implications.
-
-### Audit Reduction and Report Generation
-* 18F information systems provide an audit reduction and report generation capability.
-* 18F information systems provide the capability to automatically process audit records for events of interest based upon selectable event criteria.
-
-### Time Stamps
-* 18F information systems provide time stamps for use in audit record generation. To ensure the accuracy of the time stamp information the authoritative time source will synchronize internal information clocks at least hourly
-
-### Protection of Audit Information
-* 18F ensures its information systems protect audit information and audit tools from unauthorized access, modification and deletion. To protect audit information and audit tools log backups will be stored on a system other than the system being audited. The purpose of this requirement is to preserve information to support the review of audit history in the environment
-* Access to the Log Management framework will be relegated to personnel with a demonstrated business need for access by role. Resources who do not have a business justification should not have access.
-
-### Non-repudiation
-* 18F information systems shall provide the capability to determine whether a given individual took a particular action (e.g., created information, sent a message, approved information [e.g., to indicate concurrence or sign a contract] or received a message).
-
-### Audit Retention
-* 18F retains audit logs according to retention policy to provide support for after-the-fact investigations of security incidents and to meet regulatory and organizational information retention requirements.
-* The log management framework will provide the capability to retain logs for a minimum 90 days online and one-year offline, with sufficient capacity as to mitigate the risk of exceeding storage space.
-
-### Audit Generation
-* 18F information systems will provides audit record generation capability for the list of auditable events for its information systems and network services
-* 18F will allows designated organizational personnel to select which auditable events are to be audited by specific components of the system
-* 18F generates audit records for the list of audited events defined in AU-2 with the content as defined in AU-3.
-
-## 4. Roles and Responsibilities
-|Roles                         |Responsibilities                                               |
-|------------------------------|---------------------------------------------------------------|
-|Security Engineering          | Establishment and maintenance of log management framework
-|Senior Director               | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance        | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/CA-Policy.md
+++ b/CA-Policy.md
@@ -1,71 +1,23 @@
-# 18F Security Assessment and Authorization Policy
+# Security assessment and authorization
 
-## 1. Purpose of Policy
-Security Assessment and Authorization, formerly Certification and Accreditation, is a process of identifying, analyzing and understanding information assets, possible impact of security risks, weaknesses and threats in order to apply appropriate security measures. It is a federal requirement to assess and authorize information technology systems in accordance with FISMA the Federal Risk and Authorization and Management Program and is based on NIST Special Publication 800-37, Revision 1, Guide for Applying the Risk Management Framework to Federal Information Systems
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 3, _Policy on Management Controls_, which covers:
 
-This Policy establishes the basis for implementing a security assessment and authorization policy and practices for protecting information systems and data within 18F systems, products and networks.
+* Certification, Accreditation, and Security Assessments (CA)
+* Planning (PL)
+* Program Management (PM)
+* Risk Assessment (RA)
+* System and Services Acquisition (SA)
 
-The 18F program includes a library of security policies that address federal and commercial requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+## Purpose
 
-This policy is written and includes the following:
-* Security assessments
-* Information System Connections
-* Security Certification
-* Plan of Action and Milestones
-* Security Authorization
-* Continuous Monitoring
-* Penetration Testing
-* Internal System Connections
+Implement the [NIST Risk Management Framework](http://csrc.nist.gov/groups/SMA/fisma/framework.html), and ensure compliance with all relevant laws, regulations, policies, and Executive Orders.
 
-## 2. Scope of Policy
-This policy applies to all users, systems, networks, components, services and processes in or accessing the 18F Production environment, and all services, applications and products in General Availability.  This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+## Scope
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+## Policy overlay
 
-### Security Assessments
-* 18F will implement a security assessment plan that;
- * Describes security controls and control enhancements under assessment;
- * Defines assessment procedures used to determine security control effectiveness; and
- * Defines assessment environment, assessment team, and assessment roles and responsibilities.
-* 18F will conduct annual assessment to ensure controls are implemented correctly, operating, and producing the desire artifacts;
-* 18F will generate a Security Assessment Report and documents the outcome of annual assessment; and
-* 18F will provide results of assessment, in writing, to authorizing official or authorizing official designated representative.  
-* 18F will engage the services of an independent assessor/team to conduct assessment of the security controls.   
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-### Information System Connections
-* 18F will authorize any connections from the information system to other systems, outside the authorization boundary, through the use of * Interconnection Security Agreements;
-* 18F will document, for each connection, the interface characteristics, security requirements, and the nature of the information communicated; and
-* 18F will monitor the information system connections on an ongoing basis, verifying enforcement of security requirements.
-
-### Plan of Action and Milestones
-* 18F will establish a plan of action and milestone for the information system to document the organization’s planned remedial actions to correct weaknesses or deficiencies noted during the assessment of the security controls and to reduce or eliminate known vulnerabilities in the system
-* 18F will update existing plan of action and milestone monthly based on the findings from security controls assessments, security impact analysis and continuous monitoring activities.  
-
-### Security Authorization
-* 18F will assign a senior-level executive or manager to the role of authorizing official for the information system;
-* 18F will ensure that the authorizing official authorizes the information system for processing before commencing operations; and
-* 18F will update the security authorization on an annual basis.
-
-### Continuous Monitoring
-* 18F will implement a configuration management process for the information system and its constituent components;
-* 18F will make a determination of the security impact of changes to the information system and environment of operations;
-* 18F will conduct ongoing security control assessments in accordance with the organizational continuous monitoring strategy; and
-* 18F will report security state of the information system to appropriate organizational officials on an annual basis.
-
-### Penetration Testing
-* 18F will employ the use of an independent penetration agent or penetration team to perform penetration testing on its information system or system components
-* 18F if needed will employ authorized red team exercises to simulate attempts by adversaries to compromise organizational information systems in accordance with approved rules of engagement.
-
-### Internal System Connections
-* 18F Authorizes internal connections of information system components or classes of components to the information systems
-* Ensure to document for each internal connection, the interface characteristics, security requirements, and the nature of the information communicated.
-
-## 4. Roles and Responsibilities
-|Roles                 | Responsibilities                                                                           |
-|----------------------|--------------------------------------------------------------------------------------------|
-|Security Operations   | Responsibilities include following the Risk management framework (RMF) and POA&M management|
-|Senior Director       | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance| Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/CM-Policy.md
+++ b/CM-Policy.md
@@ -1,97 +1,27 @@
-# 18F Configuration Management Policy
+# Configuration management
 
-## 1. Purpose of Policy
-Configuration Management (CM) comprises a collection of activities focused on establishing and maintaining the integrity of products and systems, through control of the processes for initializing, changing, and monitoring the configurations of those products and systems.  
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 4, _Policy on Operational Controls_, which covers:
 
-The 18F program includes a library of security policies that address federal and commercial requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+* Awareness and Training (AT)
+* Configuration Management (CM)
+* Contingency Planning (CP)
+* Incident Response (IR)
+* Maintenance (MA)
+* Media Protection (MP)
+* Physical and Environmental Protection (PE)
+* Personnel Security (PS)
+* System and Information Integrity (SI)
 
-This policy is written to include the following
-* Baseline Configuration
-* Configuration Change Control
-* Security Impact Analysis
-* Assess Restrictions for Change
-* Configuration Settings
-* Least Functionality
-* Information System Component Inventory
-* Configuration Management Plan
+## Purpose
 
-## 2. Scope of Policy
-This policy applies to all 18F employees and contractors working in or with the 18F for Public Sector organization. Failure to comply with this policy may result in disciplinary action, up to and including termination of employment and possible civil and/or criminal penalties under the applicable U.S. laws and regulations.
+Always deploy information systems into a state known before instantiation, and to maintain information systems in an immutable state as much as feasible. To the greatest degree possible, the configuration of systems should not be altered after they are deployed - they should be rebuilt and replaced from a known and secure baseline state.
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+## Scope
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-### Baseline Configuration
-* 18F will develop and maintain documentation on the baseline configuration of the information system to include such things as, but not limited to:
- * Network topology;
- * System architecture;
- * Application, Web and Server components
- * Software standards
-* 18F will review baseline configuration settings on a continual basis and provide annual updates as required due to federal mandates and compliance standards
-* 18F will retain any and all necessary baseline configuration as deemed necessary to support rollback functions and incident response
-* 18F will develop and maintain a list of software programs/applications that are not authorized to execute on the information system, and * employs an allow-all, deny-by-exception authorization policy to identify software allowed to execute on the information system.
+## Policy overlay
 
-### Configuration Change Control
-* 18F will document changes to the baseline configuration in the following manner:
- 1. Determines the types of changes to the information system that are configuration controlled
- 2. Changes require security impact analyses conducted on all configuration-controlled changes
- 3. Maintain documentation for approved configuration-controlled changes
- 4. Provides record retention for review of configuration-controlled changes at a minimum of 1 year
- 5. Coordinates and provides oversight for configuration change control activities through tracking and monitoring systems that evaluates configuration changes  through a continuous development lifecycle
-* 18F will test, validate, and document changes to the information system before implementing the changes on an operational system.
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-### Security Impact Analysis
-* 18F will conduct a thorough security analysis of the proposed change prior to the configuration change being implemented within an operational system. Proposed and defined major changes may include :
- * an increase in the sensitivity or criticality of a system;
- * an increase in threat level;
- * policy change
- * a change in operating system (base platform);
- * a change to security relevant software;
- * installations and upgrades;
- * An increase in interconnection with other systems outside the accreditation boundary;
- * Significant changes in the security requirements that apply to the system.
-
-### Access Restriction for Change
-18F will ensure only pre-defined authorized users are allowed to make any changes to either the physical or logical environment that:
-* Defines and documents access roles;
-* Defines approval process for access; and
-* Retains records for express purpose for auditing purposes.
-
-### Configuration Settings
-18F will document the baseline configuration settings such that:
-* Mandatory configuration settings for information technology products utilized within the information system using best practices, federally approved configuration checklists,  hardening guides and standard compliance settings that reflect the most restrictive mode consistent with operational requirements
-* Implements the configuration setting within the information systems and components
-* Identifies, documents, and approves exceptions from the mandatory configuration setting
-* Monitors and controls changes to the configuration setting in accordance with 18F policies and procedures.
-
-18F will incorporate a detection of unauthorized, security-relevant configuration changes into 18F incident response capability to ensure that such detected events are tracked, monitored, corrected, and available for historical purposes.
-
-### Least Functionality
-*  18F will only grant access to information in a manner that provides only essential capabilities and specifically required  or restricts the use of the functions, ports, protocols, and/or services based on organizational policy and security requirements
-* 18F will conduct on-going and monthly reporting audit of information system which identifies and eliminates unnecessary functions, ports, protocols, and/or services.  
-
-### Information System Component Inventory
-* 18F will develop, document, and maintains inventory of information system components that:
- * Accurately reflect the current information system;
- * Is consistent with the authorization boundary of the information system;
- * Is at the level of granularity deemed necessary for tracking and reporting;
- * Includes [timeframe] archival of information system; and
- * Is available for review and audit by designated officials.
-* 18F will update inventory of information system whenever installations, removals, and other changes are made.
-* 18F will verify that all components within the authorized boundary of the information system are either inventoried as part of the system or recognized by another system as a component within that system.
-
-### Configuration Management Plan
-18F will develop a configuration management plan that:
-* Addresses roles, responsibilities, and configuration management processes and procedures;
-* Defines the configuration items for the information system and when in the system development life cycle the configuration items are placed under configuration management; and
-* Establishes the means for identifying configuration items throughout the system development life cycle and a process for managing the configuration of the configuration items.
-
-#### 4. Roles and Responsibilities
-|Roles                 | Responsibilities                                                                        |
-|----------------------|-----------------------------------------------------------------------------------------|
-|Development Operations| Maintains baseline configuration management of information systems and networks for 18F |
-|Security Operations   | Reviews configuration settings implemented on the system per established baseline configurations|
-|Senior Director       | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance| Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/CP-Policy.md
+++ b/CP-Policy.md
@@ -1,79 +1,27 @@
-# 18F Contingency Planning Policy
+# Contingency planning
 
-## 1. Purpose of Policy
-Contingency planning is a component of business continuity, disaster recovery and risk management. Its major objectives are to ensure containment of damage or injury to, or loss of, personnel and property, and continuity of the key operations of the organization.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 4, _Policy on Operational Controls_, which covers:
 
-The purpose of this policy is to ensure that 18F establishes requirements for a comprehensive program for developing, implementing and maintaining relevant information to support contingency planning objectives and security posture of the organization.
+* Awareness and Training (AT)
+* Configuration Management (CM)
+* Contingency Planning (CP)
+* Incident Response (IR)
+* Maintenance (MA)
+* Media Protection (MP)
+* Physical and Environmental Protection (PE)
+* Personnel Security (PS)
+* System and Information Integrity (SI)
 
-The 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+## Purpose
 
-This policy is written and includes the following:
-* Contingency Plan
-* Contingency Training
-* Contingency Plan Testing
-* Alternate Redundant Storage Site
-* Alternate Redundant  Processing Site
-* Telecommunications Services
-* Information system backup
-* Information system  recovery and reconstitution
+Identify scenarios of likely events that would substantively disrupt the confidentiality, integrity, or availability of the information system. Use those scenarios to conduct actual simulations of said disruptions, and use data collected from the simulation to iteratively improve training, methodologies, but above all - improve the automation of our information systems to self-heal from any disruptions.
 
-## 2. Scope of Policy
-This policy applies to all users, systems, networks, components, services and processes in or accessing the 18F Production environment, and all services, applications and products in General Availability.  This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+## Scope
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+## Policy overlay
 
-### Contingency Planning
-18F will implement contingency plans that:
-* Identify essential missions and business functions and associated contingency requirements
-* Provide recovery objectives, restoration priorities, and metrics
-* Identify roles and responsibilities
-* Maintain essential mission and business functions despite information system disruption, compromise, or failure; and
-* Identify full system restoration without deterioration of the security measure as originally planned and implemented.
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-### Contingency Training
-* 18F will provide designated contingency personnel with annual training on their roles and responsibilities.
-
-### Contingency Plan Testing and Exercises
-* On an annual basis, 18F will conduct a test of the contingency plan with all appropriate personnel identified as part of the Contingency Plan and report finding back to 18F Senior Management
-* 18F will review and provide appropriate Contingency Plan updates based off annual tests.  
-
-### Alternate Redundant Storage Site
-* 18F will utilize cloud computing infrastructure capabilities to leverage established redundant storage sites within (Amazon Web Services (AWS)  US regions) and federally located facilities for the storage and recovery of information
-* All regional sites and availability zones should be physically separated from other sites and 18F will identify and remediate potential accessibility problems to the regional sites in the event of an area-wide disruption or disaster.  
-
-### Alternate Redundant Processing Site
-* 18F shall utilize the capabilities of cloud infrastructure as a service (IaaS), to establish redundant processing sites; including necessary agreements to permit the resumption of information operations for essential mission and business functions within an approved time period when the primary processing capabilities are unavailable
-* 18F will ensure the availability of all provided services, processes, and work flows required to resume operations are available to support the 18F defined time period for resumption
-* 18F will ensure to use regional sites that are physically separated from other storage sites within the united states
-* 18F will identify and remediate potential accessibility problems to the AWS site in the event of an area-wide disruption or disaster
-* 18F alternative processing site agreements will contain priority-of-service provisions in accordance with 18F availability requirements
-* 18F will ensure that redundant processing sites provides information security measures equivalent to that of a primary processing site.
-
-### Telecommunications Services
-* 18F shall leverage cloud computing redundancy capabilities for alternative telecommunication services for the resumption of system operations for essential missions and business functions within an approved time period from when the primary telecommunications capabilities are unavailable  
-* 18F will leverage primary and alternate telecommunications service agreements that contain priority-of-service provisions in accordance with 18F availability requirements
-* 18F request telecommunications service priority for all telecommunications services used for national security emergency preparedness in the event that either the primary or alternate telecommunications services are unavailable
-* 18F will utilize the cloud infrastructure secondary telecommunication service providers to reduce the likelihood of a single point-of-failure with primary telecommunications service provider.
-
-### Information System Backup
-* 18F conducts pre-defined backups of user-level information contained in the information system.
-* 18F conducts pre-defined backups of system-level information contained in the information system.
-* 18F conducts pre-defined backups of information system documentation including security related documentation.  
-* 18F will protect the confidentiality an integrity of backup information
-* 18F will test backup of information on an [annual] basis to verify media reliability and information integrity.  
-
-### Information System Recovery and Reconstitution
-* 18F will provide for the recovery and reconstitution of the information system to a known state after a disruption, compromise, or failure.  
-* 18F implements transaction recovery for systems that is transaction-based.
-* 18F will provide compensating security controls in the event that system recovery and reconstitution of its information systems has not been fully restored.
-
-## 4. Roles and Responsibilities
-|Roles                  |Responsibilities|
-|-----------------------|-------------------------------------------------------------------------------------------------------|
-|Development Operations |The safety and security of data on network and the equipment used to run the network infrastructure.
-|Disaster Recovery Team | Designated members from 18F will implement, test and reconstitute information systems based on defined contingency plans and procedures|
-|Senior Director        | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/IA-Policy.md
+++ b/IA-Policy.md
@@ -17,4 +17,6 @@ See the **_Applicability_** section of the [GSA IT Security Policy](http://www.g
 
 ## Policy overlay
 
-For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Services's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
+
+## Procedures

--- a/IR-Policy.md
+++ b/IR-Policy.md
@@ -1,82 +1,27 @@
-# 18F Incident Response Policy
+# Incident response
 
-## 1. Purpose of Policy
-Incident Response (IR) is an organized approach to addressing and managing the aftermath of a security breach or attack (also known as an incident). The goal is to handle the situation in a way that limits damage and reduces recovery time and costs.
-This Policy establishes the basis for implementing an incident response policy and practices for protecting information systems and data within 18F systems, products and networks.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 4, _Policy on Operational Controls_, which covers:
 
-The 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+* Awareness and Training (AT)
+* Configuration Management (CM)
+* Contingency Planning (CP)
+* Incident Response (IR)
+* Maintenance (MA)
+* Media Protection (MP)
+* Physical and Environmental Protection (PE)
+* Personnel Security (PS)
+* System and Information Integrity (SI)
 
-This policy is written and includes the following:
-* Incident Response Training
-* Incident Response Testing
-* Incident Handling
-* Incident Monitoring
-* Incident Reporting
-* Incident Response Assistance
-* Incident Response Plan
-* Information spillage response
+## Purpose
 
-## 2. Scope of Policy
-This policy applies to all users, systems, networks, components, services and processes in or accessing the 18F Production environment, and all services, applications and products in General Availability.  This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+Iteratively reduce both the number of incidents as a proportion of our total information system inventory, and reduce the mean time to recover from incidents.
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+## Scope
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-### Incident Response Training
-* 18F must provide incident response training to information system users consistent with assigned roles and responsibilities: Within 60 * days of assuming an incident response role or responsibility; when required by information system changes; and annually thereafter.
-* 18F will incorporates simulated events into incident response training to facilitate effective response by personnel in crisis situations.
-* 18F will employ automated mechanisms to provide a more thorough and realistic incident response training environment.
+## Policy overlay
 
-### Incident Response Testing
-* 18F must test the incident response capability for its information systems annually using (i.e. walk-through or tabletop exercises, simulations (parallel/full interrupt), and comprehensive exercises) to determine the incident response effectiveness and documents the results.
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-### Incident Handling
-* 18F must implement incident handling capability for security incidents that includes preparation, detection and analysis, containment, eradication, and recovery;
-* Coordinate incident handling activities with contingency planning activities
-* Incorporate lessons learned from ongoing incident handling activities into incident response procedures, training, and testing, and implements the resulting changes accordingly.
-
-### Incident Monitoring
-* 18F must track and document information system security incidents maintaining records about each incident, the status of the incident, and other pertinent information necessary for forensics, evaluating incident details, trends, and handling.
-* 18F must employ automated mechanisms to assist in the tracking of security incidents and in the collection and analysis of incident information.
-
-### Incident Reporting
-* 18F requires personnel to report suspected security incidents to the organizational incident response capability within [Assignment: organization-defined time period]; and
-* Report security incident information to United States Computer Emergency Readiness Team (US-CERT) and other federal agencies as required.
-
-### Incident Response Assistance
-* 18F must provide the capability of an incident response support resource, integral to the organizational incident response capability that offers advice and assistance to users of the information system for the handling and reporting of security incidents.
-* Incident response support resources provided by 18F can include, for example, help desks, assistance groups, and access to forensics services, when required.
-
-### Incident Response Plan
-* 18F must develop an incident response plan that:
- * Provides the organization with a roadmap for implementing its incident response capability;
- * Describes the structure and organization of the incident response capability;
- * Provides a high-level approach for how the incident response capability fits into the overall organization;
- * Meets the unique requirements of the organization, which relate to mission, size, structure, and functions;
- * Defines reportable incidents;
- * Provides metrics for measuring the incident response capability within the organization;
- * Defines the resources and management support needed to effectively maintain and mature an incident response capability
- * Reviewed and approved by the 18F Infrastructure Manager and ISSM;
-* Distribute copies of the incident response plan to all designated incident response POCs, 18F managers and system owners
-* Review the incident response plan at least on an annual basis and update the incident response plan to address system/organizational changes or problems encountered during plan implementation, execution, or testing
-* Communicate incident response plan changes to all designated incident response POCs  and 18F managers and system owners
-Protects the incident response plan from unauthorized disclosure and modification
-
-### Information Spillage Response
-* 18F responds to information spills by:
- * Identifying the specific  information involved in the information system contamination
- * Alerting designated incident response  personnel,  system owners , Information system security officers  and other POCs  of the information spill  using methods of communication not associated with the spill
- * Isolating the contaminated information system or system component
- * Eradicating the information from the contaminated information system or component
- * Identifying other information systems or system components that may have been subsequently contaminated
-
-## 4. Roles and Responsibilities
-|Roles                  | Responsibilities|
-|-----------------------|-----------------------------------------------------------------------------------------------------|
-|Development Operations | The safety and security of data on network and the equipment used to run the network infrastructure.|
-|Security Operations    | Monitor security posture of the information systems and reports any suspicious activities within the network to the appropriates POCs|
-|Incident Response Team | Designated incident response personal will activate the IPR plan and follow the IR procedures|
-|Senior Director        | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/PL-Policy.md
+++ b/PL-Policy.md
@@ -1,54 +1,23 @@
-# 18F security Planning Policy
+# Security planning
 
-## 1. Purpose of Policy
-The objective of system security planning is to improve protection of information system resources. The purpose of system security plans is to provide an overview of the security requirements of information systems and describe the controls in place or planned for meeting those requirements. The system security plan should be viewed as documentation of the structured process of planning adequate, cost-effective security protection for a system.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 3, _Policy on Management Controls_, which covers:
 
-This Policy establishes the basis for implementing security planning practices for protecting information systems and data within 18F systems, products and networks.
+* Certification, Accreditation, and Security Assessments (CA)
+* Planning (PL)
+* Program Management (PM)
+* Risk Assessment (RA)
+* System and Services Acquisition (SA)
 
-The 18F program includes a library of policies that address federal and commercial requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+## Purpose
 
-This policy is written to include the following:
-* System Security Plan
-* Rules of Behavior
-* Information Security Architecture
+Create system security plans, diagrams, rules, privacy impact assessments, and operational procedures that are easy to understand, enforce, implement, and that reduce complexity wherever it can be found. 
 
-## 2. Scope of Policy
-This policy applies to all users, systems, networks, components, services and processes in or accessing the 18F Production environment, and all services, applications and products in General Availability.  This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+## Scope
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-### System Security Plans
-* 18F will create, modify and implement System Security Plans (SSP) that:
- * Remain consistent with 18F enterprise architecture;
- * Explicitly defines the authorization boundary for information systems;
- * Describes the operational context of the information system in terms of mission and business process;
- * Provides the security categorization of the information system including supporting rationale;
- * Describes the operational environment for the information systems;
- * Describes relationships with or connections to other information systems;
- * Provides an overview of the security requirements for the systems;
- * Describes the security controls in place or planned for meeting those requirements; including a rationale for the tailoring and supplementation decision;
- * Reviewed and approved by authorizing official or designated representative prior to plan implementation
-* Distributes copies of the security plan and communicates subsequent changes to the plan to information system owners, information system security officers/managers and, authorizing officials and others on a need to know basis
-* 18F must review the system security plans for information systems annually and update system security plans to address changes to the information system/environment of operation or problems identified during plan implementation or security control assessments.
-* Protects security plans from unauthorized disclosure and modification.
+## Policy overlay
 
-### Rules of Behavior
-* 18F will establish and make readily available to all users the rules that describe their responsibilities and expected behavior with regards to information and information system usage
-* 18F documents acknowledgment from users indicating that they have read, understand, and agree to abide by the rules of behavior, before authorizing access to information and information systems.
-* 18F reviews and updates the rules of behavior on an annual basis and requires individuals who have signed a previous version of the rules of behavior to read and re-sign when the rules of behavior are revised/updated.
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-### Information Security Architecture
-18F develops information security architecture for its information systems that:
-* Describes the overall philosophy, requirements, and approach to be taken with regard to protecting the confidentiality, integrity, and availability of organizational information
-* Describes how the information security architecture is integrated into and supports the enterprise architecture and any information security assumptions about and dependencies on external services
-* Reviews and updates the information security architecture on a periodic basis to reflect updates in the enterprise architecture
-* Ensures that planned information security architecture changes are reflected in system security plans and organizational procurements/acquisitions.
-
-## 4. Roles and Responsibilities
-|Roles                  | Responsibilities|
-|---------------------- |-----------------------------------------------------------------------------------------------------|
-|Development Operations | Implement the security controls documented within the system security plans and network architecture|
-|Security Operations    | Ensure documentation of the 18F information systems and network architecture is complete accurate and meeting the security requirements of policies and standards|
-|Senior Director        | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/PS-Policy.md
+++ b/PS-Policy.md
@@ -1,80 +1,27 @@
-# 18F Personnel Security Policy
+# Personnel security
 
-## 1. Purpose of Policy
-The greatest disruption to a system comes from the actions of individuals, both intentional and unintentional. Users, designers, implementers, and managers are involved in many important issues in securing the information contained within the 18F program.
-The purpose of this policy is to outline 18F security measures to ensure that employees, contractors, and vendors understand their responsibilities, and are suitable for the roles they are considered for, and reduce the risk of theft, fraud or misuse of 18F systems and information.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 4, _Policy on Operational Controls_, which covers:
 
-This Policy establishes the basis for implementing Personnel Security (PS) practices for protecting information systems and data within 18F systems, products and network.
+* Awareness and Training (AT)
+* Configuration Management (CM)
+* Contingency Planning (CP)
+* Incident Response (IR)
+* Maintenance (MA)
+* Media Protection (MP)
+* Physical and Environmental Protection (PE)
+* Personnel Security (PS)
+* System and Information Integrity (SI)
 
-The 18F program includes a library of policies that address federal and commercial requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+## Purpose
 
-This policy is written to include the following:
-* Position Categorization
-* Personnel Screening
-* Personnel Termination
-* Personnel Transfer
-* Access Agreements
-* Third-Party Personnel Security
-* Personnel Sanctions
+Reduce the risk of insider threats or internal conspiracies to circumvent the confidentiality, integrity, or availability of information systems.
 
-## 2. Scope of Policy
-This policy is applicable to all 18F employees, contractors, and vendors. This policy applies to all users, systems, networks, components, services and processes in or accessing the 18F Production environment, and all services, applications and products in General Availability.  This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+## Scope
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+## Policy overlay
 
-## Position Categorization
-* 18F shall assign a risk designation to all positions and establishes screening criteria for individuals filling those positions. The organization reviews and revises position risk designations once every two years.
-* Management responsibilities must include ensuring that employees, contractors, and third-party users are properly briefed on their information security roles and responsibilities prior to being granted access to sensitive information or information systems.
-Ensure that employees, contractors, and third-party users are provided with guidelines to state security expectations of their role within the organization.
-* Ensure that employees, contractors, and third-party users conform to the terms and conditions of employment, which includes the organization’s information security policy and appropriate methods of working.
-* Ensure that employees, contractors, and third-party users achieve a level of awareness on security relevant to their roles and responsibilities within the organization
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
-## Personnel Screening
-* 18F develops implements and maintains procedures to perform personnel screening in the recruiting process prior to allowing personnel access to the company’s physical facilities and electronic resources. Examples of personnel screening procedures include: who is eligible to screen people, and how, when and why verification checks are carried out; background checks include all relevant privacy, protection of personal data and/or employment based legislation; character references; accuracy and completeness of resumes; identity checks; criminal and credit checks; immigration checks.
-* 18F ensures that every user accessing an information system processing, storing, or transmitting classified information is cleared and indoctrinated to the highest classification level of the information on the system.
-* 18F ensures that every user accessing an information system processing, storing, or transmitting types of classified information which require formal indoctrination, is formally indoctrinated for all of the relevant types of information on the system.
-* Information on all candidates being considered for positions within 18F is collected and handled in accordance with any appropriate legislation existing in the relevant jurisdiction. As appropriate and required by law, candidates are informed beforehand about the screening activities.
-
-## Personnel Termination and Transfer
-* When employment is terminated, 18F
- * terminates information system access
- * conducts exit interviews
- * ensures the return of all organizational information system-related property (e.g., keys, identification cards, building passes)
- * Ensures that appropriate personnel have access to official records created by the terminated employee that are stored on organizational information systems.
-* If a departing employee, contractor or third-party user has known passwords for accounts remaining active, these are changed upon termination of employment, contract, or agreement.
-* In cases where an employee, contractor, or third-party user purchases the organization’s equipment or uses their own personal equipment, procedures should be followed to ensure that all relevant information is transferred to the organization and securely erased from the equipment
-* 18F reviews information systems/facilities access authorizations when personnel are reassigned or transferred to other positions within the organization and initiates appropriate actions (e.g., reissuing keys, identification cards, building passes, closing old accounts, establishing new accounts and changing system access authorizations).
-* Employee terminations and transfers are reviewed at a planned frequency to verify that termination procedures and/or entitlement changes are conducted properly.
-
-## Access Agreements
-* All employees, contractors, and vendors must sign agreements to safeguard sensitive data prior to accessing 18F information resources. The agreements must include the following:
- * Non-Disclosure Agreement
- * Acceptable Use Policy
- * Access Agreement
- * Code of Conduct Policy
-* 18F completes appropriate access agreements for individuals (employees, contractors, and/or other third-parties) requiring access to organizational information before authorizing access to the company’s physical assets and electronic resources. The agreements shall be signed as part of the new hiring process and engaging third parties.
-* 18F retains the agreements above with employee/contractor/user records.
-* 18F reviews and update the agreements at least annually.
-
-## Third-Party Personnel Security
-* 18F shall establish personnel security requirements for third-party providers (e.g., service bureaus, contractors and other organizations providing information system development, information technology services, outsourced applications, network and security management) and monitors provider compliance to ensure adequate security.
-
-## Personnel Sanctions
-* 18F must employ a formal sanctions process for personnel failing to comply with established information security policies and procedures.
-* The gross negligence or willful disclosure of 18F information can result in prosecution for misdemeanor or felony resulting in fines, imprisonment, civil liability, and/or dismissal. Unauthorized personnel are not allowed to see or obtain sensitive data.
-* 18F must define and implement a process to monitor, identify, and sanction employees, contractors, and vendors who fail to comply with 18F security policies and procedures.
-* 18F must notify the 18F Security Office (SSO) of any incidents of non-compliance with 18F security policies and procedures.
-* The disciplinary process should not be commenced without prior verification that a security breach has occurred.
-* In serious cases of misconduct, the process should allow for instant removal of duties, access rights, privileges, immediate escorting and removal from the site, or termination, if necessary.
-
-## 4. Roles and Responsibilities
-|Roles           |Responsibilities|
-|------------------------|--------------------------------------------------------------------------------------------------------------|
-|18F Program Management Office (PMO)| Determines security access requirements for all positions Ensures all personnel are trained in the computer security responsibilities and duties associated with their jobs
-|18F Information Security Office (SSO)| Monitors adherence to the personnel security policy Ensures that all personnel have undergone background checks and security training
-|Human Resources        | Ensures that all personnel have undergone the appropriate background checks|
-|Senior Director        | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/RA-Policy.md
+++ b/RA-Policy.md
@@ -1,6 +1,6 @@
 # Risk assessment policy
 
-See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 5, _Policy on Technical Controls_, which covers:
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 3, _Policy on Management Controls_, which covers:
 
 * Certification, Accreditation, and Security Assessments (CA)
 * Planning (PL)

--- a/RA-Policy.md
+++ b/RA-Policy.md
@@ -18,4 +18,6 @@ See the **_Applicability_** section of the [GSA IT Security Policy](http://www.g
 
 ## Policy overlay
 
-For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Services's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
+
+## Procedures

--- a/SA-Policy.md
+++ b/SA-Policy.md
@@ -1,95 +1,23 @@
-# 18F System and Services Acquisition Policy
+# System and services acquisition
 
-## 1. Purpose of Policy
-The purpose of this policy is to ensure that 18F establishes requirements for a comprehensive program for developing, implementing and maintaining relevant information to support system and services acquisition policy objectives and security posture of the organization.
-The 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 3, _Policy on Management Controls_, which covers:
 
-This policy is written to include the following:
-* Allocation of Resources
-* Life Cycle Support
-* Acquisitions
-* Information System Documentation
-* Software Usage Restrictions
-* User-installed Software
-* Security Engineering Principles
-* External Information System Services
-* Developer Configuration Management
-* Developer Security Testing
+* Certification, Accreditation, and Security Assessments (CA)
+* Planning (PL)
+* Program Management (PM)
+* Risk Assessment (RA)
+* System and Services Acquisition (SA)
 
-## 2. Scope of Policy
-This policy applies to all users, systems, networks, components, services and processes in or accessing the 18F Production environment, and all services, applications and products in General Availability.  This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+## Purpose
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+Continue forming teams of cross-functional skill sets that include security and privacy experts. Always keep a reserve of funding, time, and staff in order to provide for unexpected increases in the need for  architectural and security engineering assistance, at any phase in an information system development life cycle.
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+## Scope
 
-#### Allocation of Resources
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-* 18F will implement a mission/business process planning
-* 18F will conduct annual assessment to ensure controls are implemented correctly, operating, and producing the desire artifacts;
-* 18F will generate a Security Assessment Report and document the outcome of [annual] assessment; and
-* 18F will establish a discrete line item for information security in organizational programming and budgeting documentation.  
+## Policy overlay
 
-### Life Cycle Support
-* 18F will manage the information system using a system development life cycle methodology that includes information security considerations;
-* 18F will define and document information system security roles and responsibilities throughout the system development life cycle; and
-* 18F will identify individuals having information system security roles and responsibilities.  
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
 
-### Acquisitions
-* 18F will include the following requirements and/or specifications, explicitly or by reference, in information system acquisition contracts based on an assessment of risk and in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards:
-  * Security functional requirements and specifications;
-  * Security-related documentation requirements; and
-  * Development and evaluation-related assurance requirements.
-* 18F requires that acquisition documents that vendors/contractors provide information describing the functional properties of the security controls to be employed within the information system, information system components, or information system services in sufficient detail to permit analysis and testing of the controls.
-* 18F requires that each information system component acquired is explicitly assigned to an information system, and that the owner of the system acknowledges this agreement.
-
-### Information System Documentation
-* 18F will develop and maintain administrator documentation for the information system, making it available upon request by authorized personnel, that includes the following:
-  * Secure configuration, installation, and operation of the information system;
-  * Effective use and maintenance of security features/functions; and
-  * Known vulnerabilities regarding configuration and use of administrative (i.e. privileged) functions.
-* 18F will develop and maintain user documentation for the information system, making it available upon request by authorized personnel, that includes the following:
-  * User-accessible security features/functions and how to effectively use those security features/functions;
-  * Methods for user interactions with the information system; and
-  * User responsibilities in maintaining the security of the information and information system.
-* 18F will document attempts to obtain information system documentation when such documentation is either unavailable or nonexistent.
-* 18F will maintain vendor documentation, as required and protected, that describes the functional properties of the security controls employed within the information system with sufficient detail to permit analysis and testing.
-* 18F will maintain vendor documentation, as required and protected, that describes the high-level design of the information system in terms of subsystems and implementation details of the security controls employed within the system with sufficient detail to permit analysis and testing.
-
-### Software Usage Restrictions
-* 18F will use software and associated documentation in accordance with contract agreement and copyright laws;
-* 18F will employ a tracking system for software and associated documentation protected by quantity licenses to control copying and distribution; and
-* 18F will document the utilization of peer-to-peer file sharing technology ensuring that it will not be used for unauthorized distribution, display, performance, or reproduction of copyrighted material.  
-
-### User-installed Software
-* 18F plans will document what software may or may not be installed; security patches installation, and who is authorized to install such software.
-
-### Security Engineering Principles
-* 18F will apply information system security engineering principles in to the specifications, design, development, implementation, and modification of the information system.
-
-### External Information System Services
-* 18F will require external information system providers to comply with 18F information system requirements and employ appropriate security controls in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
-* 18F will define and document government oversight and user roles and responsibilities with regards to external information system services
-* 18F will monitor security control compliance by external service providers.  
-
-### Developer Configuration Management
-* 18F requires that information system developers/integrators:
-  * Perform configuration management during information system design, development, implementation, and operation;
-  * Manage and control changes to the information system;
-  * Implement only organization-approved changes;
-  * Document approved changes to the information system; and
-  * Track security flaws and flaw resolution.
-
-### Developer Security Testing
-* 18F requires that information system developers/integrators, in consultation with associated security personnel;  
-  * Create and implement a security test and evaluation plan;
-  * Implement a verifiable flaw remediation process to correct weaknesses and deficiencies identified during the security testing and evaluation process; and
-  * Document the results of the security testing/evaluation and flaw remediation processes.  
-
-## 4. Roles and Responsibilities
-| Roles                  | Responsibilities                                                                                     |
-|------------------------|------------------------------------------------------------------------------------------------------|
-|Development Operations  | The safety and security of data on network and the equipment used to run the network infrastructure. |
-|Senior Director         | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance  | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/SC-Policy.md
+++ b/SC-Policy.md
@@ -1,121 +1,22 @@
-# 18F Systems and Communications Protection Policy
+# Systems and communications protection
 
-## 1. Purpose of Policy
-System Communication protection is the process of implementing protective measures both logically and physically to ensure consistent, uninterrupted, and tamper resistant availability of communication channels and data are provided to information systems and users who require access to the data.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 5, _Policy on Technical Controls_, which covers:
 
-The purpose of this policy is to establish the basis for implementing system and communications practices for protecting information systems and data within 18F systems, products and networks.
+* Access Control (AC)
+* Audit and Accountability (AU)
+* Identification and Authentication (IA)
+* System and Communications Protection (SC)
 
-The 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
+## Purpose
 
-This policy is written to include the following
-* Application Partitioning
-* Security Function Isolation
-* Information Remnants
-* Denial of Service Protection
-* Boundary Protection
-* Transmission Confidentiality and Integrity
-* Network Disconnect
-* Cryptographic Key Establishment and Management
-* Cryptographic Protection
-* Public Access Protections
-* Collaborative Computing
-* Public Key Infrastructure Certificates
-* Mobile Code
-* Voice Over Internet Protocol
- /Secure Name / Address Resolution Service  (Authoritative Source)
-* Architecture and Provisioning for Name Address Resolution Service
-* Protection of Information At Rest
-* Session Authenticity
-* Fail In Known State
+Create information systems with the most sophisticated, strongest, and reasonable cryptographic methodologies available. Structure networks with the lowest amount of access and trust possible, achieving "zero trust" network systems and designs wherever possible. Ensure communication channels fail into "closed states" if the confidentiality or integrity of the communication channel is disrupted.
 
-## 2. Scope of Policy
-This policy applies to all users, systems, networks, components, services and processes in or accessing the 18F Production environment, and all services, applications and products in General Availability.  This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+## Scope
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+## Policy overlay
 
-### Application Partitioning
-* All 18F information systems must separate user functionality (including user interface services) from information system management functionality and implement separate authentication methods for privileged user access
-* Use logical separation through the use of routers, domains, virtualization, network addresses
-* Use of multi-factor authentication and Role based access controls.
-* 18F shall partition its information systems into components residing in separate logical domains (or environments) as deemed necessary.
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
 
-### Information Shared Resources
-* 18F information systems shall prevent unauthorized and unintended information transfer via shared system resources.
-
-### Denial of Service Protection
-* 18F information systems must protect against or limits the effects of denial of service (DoS) attacks including, but not limited to, Buffer Overflow attacks, Smurf attacks, PING of DEATH attacks, Teardrop attacks, SYN attacks; virus-induced DoS.
-* 18F information systems must restrict the ability of users to launch denial of service attacks against other information systems or networks
-* 18F information systems must have the capability to manage excess capacity, bandwidth, or other redundancy to limit the effects of information flooding types of denial service attacks
-* 18F shall use a combination of intrusion detection/prevention systems, firewalls, gateways, network/security operation centers, harden configuration settings, antivirus, malware mechanisms to assist in denial of service protection
-
-### Boundary Protection
-* 18F information systems must monitor and control communications at the external boundary of the information system and at key internal boundaries within the system.
-18F must connect to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with approved security architecture.
-* 18F shall logically allocates publicly accessible information system components to separate sub-networks with separate logical network interfaces
-* 18F information systems must prevent public access into the organizations internal networks except as appropriately mediated by managed interfaces employing boundary protection devices.
-* 18F must limit the number of access points to the information system to allow for more comprehensive monitoring of inbound and outbound communications and network traffic.
-* 18F information systems at managed interfaces must, deny network traffic by default and allows network traffic by exception (i.e., deny all, permit by exception).
-* 18F information systems must prevent remote devices that have established a non-remote connection with the system from communicating outside of that communications path with resources in external networks.
-
-### Transmission Confidentiality and Integrity
-* 18F information systems must protect the confidentiality and integrity of transmitted information.
-* 18F must employ cryptographic mechanisms to prevent unauthorized disclosure of information during transmission unless otherwise protected by alternative physical measures.
-
-### Network Disconnect
-* 18F information systems must terminate the network connection associated with a communications session at the end of the session or after 20 minutes of inactivity.
-
-### Cryptographic Key Establishment and Management
-* 18F information systems must employ automated mechanisms with supporting procedures or manual procedures for cryptographic key establishment and key management.
-* Define key management requirements in accordance with applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance, specifying appropriate options, levels, and parameters.
-* Manage trust stores to ensure that only approved trust anchors are in such trust stores. This includes certificates with visibility external to organizational information systems and certificates related to the internal operations of
-
-### Cryptographic Protection
-* 18F information systems must implement required cryptographic protections using cryptographic modules that comply with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
-* The information system implements applicable NSA-approved cryptography, provision of digital signatures and FIPS-validated cryptography in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
-
-### Public Access Protections
-* For publicly available systems, 18F information systems must protect the integrity of the information and applications.
-
-### Collaborative Computing
-* 18F information systems must prohibit remote activation of collaborative computing mechanisms (e.g., video and audio conferencing) and provides an explicit indication of use to the local users (e.g., use of camera or microphone).
-
-### Public Key Infrastructure Certificates
-* 18F must develop and implement a certificate policy and certification practice statement for the issuance of public key certificates used in the information systems.
-
-### Mobile Code
-* 18F must establish usage restrictions and implementation guidance for mobile code technologies based on the potential to cause damage to the information system if used maliciously
-* 18F must document, monitor and control the use of mobile code within the information system.
-
-### Voice over Internet Protocol
-* 18F shall establish usage restrictions and implementation guidance for Voice over Internet Protocol (VoIP) technologies based on the potential to cause damage to the information system if used maliciously
-* Authorizes, monitors, and controls the use of VoIP within the information system if applicable.
-
-### Secure Name / Address Resolution Service (Authoritative Source)
-* 18F will provides additional data origin authentication and integrity verification artifacts along with the authoritative name resolution data any system returns in response to external name/address resolution queries
-* Provides the means to indicate the security status of child zones and (if the child supports secure resolution services) to enable verification of a chain of trust among parent and child domains, when operating as part of a distributed, hierarchical namespace.
-* 18F shall leverage approved DNS services provided by authorized cloud infrastructure providers as needed for its information systems.
-
-### Architecture and Provisioning for Name / Address Resolution Service
-* 18F shall implement name/address resolution using domain name system (DNS) servers that are fault-tolerant and implement internal/external role separation
-* 18F shall eliminate single points of failure and enhance redundancy, by implementing multiple authoritative domain name system (DNS) servers or by leveraging approved DNS services from a third party.
-* DNS servers with an internal role, only process name/address resolution requests from within the organization (i.e., internal clients). DNS servers with an external role only process name/address resolution information requests from clients external to the organization (i.e., on the external networks including the Internet).
-* The set of clients that can access an authoritative DNS server in a particular role is specified by the 18F
-
-### Protection of Information at Rest
-* 18F information systems must protect the confidentiality and integrity of information at rest by employing cryptographic mechanisms to prevent unauthorized disclosure and modification of information at rest unless otherwise protected by alternative physical measures
-
-### Session Authenticity
-* 18F information system must protects the authenticity of communications sessions
-
-### Fail In Known State
-* All  information systems must possess the capability to fail to a defined known-state such as previous snapshots or implement high availability components for  preserving the system state information in failure scenarios
-
-## 4. Roles and Responsibilities
-|Roles                  | Responsibilities                                                                                     |
-|-----------------------|------------------------------------------------------------------------------------------------------|
-|DevOps                 | Ensure the safety and security of data on network and the equipment used to run the network infrastructure. |
-|Senior Director        | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|
+## Procedures

--- a/SI-Policy.md
+++ b/SI-Policy.md
@@ -1,94 +1,27 @@
-# 18F System and Information Integrity Policy
+# System and information integrity policy
 
-## 1. Purpose of Policy
-Systems and information integrity is the assurance that data and information systems being accessed,  have neither been tampered with altered or compromised through system errors, malicious attacks and unauthorized access during operation and transmission.
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 4, _Policy on Operational Controls_, which covers:
 
-The purpose of this policy is to ensure that 18F establishes requirements for a comprehensive program for developing, implementing and maintaining relevant information to support system and information integrity objectives and security posture of the organization.
+* Awareness and Training (AT)
+* Configuration Management (CM)
+* Contingency Planning (CP)
+* Incident Response (IR)
+* Maintenance (MA)
+* Media Protection (MP)
+* Physical and Environmental Protection (PE)
+* Personnel Security (PS)
+* System and Information Integrity (SI)
 
-The 18F program includes a library of security policies that address federal and non-federal requirements. These policies guide and govern the actions of 18F employees and contractors in conducting any United States (U.S.) business.
-This policy is written to include the following:
-* Flaw Remediation
-* Malicious Code Protection
-* Information system monitoring
-* Security Alerts and Advisories
-* Security Function Verification
-* Software, Firmware and Information Integrity
-* Spam Protection
-* Information Input Validation
-* Error Handling
-* Information Handling and Retention
-* Memory Protection
+## Purpose
 
-## 2. Scope of Policy
-This policy applies to all users, systems, networks, components, services and processes in or accessing the 18F Production environment, and all services, applications and products in General Availability.  This includes cloud infrastructure components, leveraged services and other elements used to deliver 18F products and services.
+Ensures information systems have not been compromised through system errors, malicious attacks, or unauthorized access during operation and transmission.
 
-Please see the 18F Governance Policy for further information on Management Commitment, Compliance and Enforcement, Review & Update processes, and Penalties.
+## Scope
 
-## 3. Policy
-The access and use of Information Technology (IT) resources shall be in compliance with applicable Federal Information Processing Standards (FIPS) and National Institute of Standards and Technology (NIST) Special Publications, International Organization for Standards (ISO) and 18F policies and standards.
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
 
-### Flaw Remediation
-* 18F shall identify information systems containing software affected by recently announced software flaws and reports this information to designated organizational officials with information security responsibilities (e.g., senior information security officers, information system security managers, information systems security officers).
-* 18F shall promptly install security-relevant software updates (e.g., patches, service packs, and hot fixes)  discovered during security assessments, continuous monitoring, incident response activities, or information system error handling, are also addressed expeditiously.
-* 18F must use resources such as the Common Weakness Enumeration (CWE) or Common Vulnerabilities and Exposures (CVE) databases in remediating flaws discovered within its information systems.
-* Flaw remediation must be incorporated into the configuration management process, with the intention of tracking and verifying of required/anticipated remediation actions.
+## Policy overlay
 
-### Malicious Code Protection
-* 18F shall employ malicious code protection mechanisms at information system entry and exit points on the network to detect and eradicate malicious code that is:
- * Transported by electronic mail, electronic mail attachments, web accesses, removable media, or other common means or inserted through the exploitation of information system vulnerabilities.
-* Update malicious code protection mechanisms (including signature definitions) whenever new releases are available in accordance with organizational configuration management policy and procedures.
-* Implement secure coding practices, configuration management and control, trusted procurement processes, and monitoring practices for additional malicious code protection
-* All malicious code protection mechanisms must be configured to:
- * Perform periodic scans of information systems and real-time scans of files from external sources as the files are downloaded, opened, or executed in accordance with organizational security policy
- * Block malicious code, quarantine malicious code, and send alerts to administrator in response to malicious code detection
-* Address the receipt of false positives during malicious code detection and eradication and the resulting potential impact on the availability of the information system.
-* 18F shall centrally manage virus protection mechanisms that automatically update malicious code protection mechanisms (including signature definitions) and prevent non-privileged users from circumventing malicious code protection capabilities.
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Services's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
 
-### Information System Monitoring
-* 18F must monitor information systems to detect attacks and indicators of potential attacks of unauthorized local, network, and remote connections in accordance with continuous monitoring and incident response requirements
-* Identify unauthorized use of the information system through deployed intrusion detection systems, intrusion prevention systems, malicious code protection software, scanning tools, audit record monitoring software and network monitoring software
-* Deploy monitoring devices strategically within the information system to collect organization-determined essential information and at ad hoc locations within the system to track specific types of transactions of interest to the organization
-* Protects information obtained from intrusion-monitoring tools from unauthorized access, modification, and deletion
-* Heighten the level of information system monitoring activity whenever there is an indication of increased risk to organizational operations and assets, individuals, other organizations, or the Nation based on law enforcement information, intelligence information, or other credible sources of information
-* Obtains legal opinion with regard to information system monitoring activities in accordance with applicable federal laws, Executive Orders, directives, policies, or regulations; and
-* Provides all information system monitoring information to senior information security officers, information system security managers, and information systems security officers as needed and on a continual basis.
 
-### Security Alerts, Advisories and Directives
-* 18F shall receive information system security alerts/advisories on a regular basis from the US-Cert and other sources such as the National Vulnerability database (NVD)
-* Generate internal security alerts, advisories, and directives as deemed necessary and disseminate to senior information security officers, information system security managers, and information systems security officers, systems owners, incident response teams and external agencies including Department of Homeland Security (DHS), and OPM
-* Implements an appropriate action in response to security directives in accordance with established time frames, or notifies the issuing organization of the degree of noncompliance.
-* 18F shall employ automated mechanisms to make security alert and advisory information available throughout the organization as appropriate.
-
-### Security Function Verification
-* All information systems must verify the correct operation of transitional states which include system startup, restart, shutdown, and abort functions
-* Performs verification of system startup, restart, shutdown, and abort functions upon command by approved users with appropriate privileges in real time
-* Notifies senior information security officers, information system security managers, and information systems security officers of failed security verification tests and shuts down or restarts the information system when anomalies are discovered.
-
-### Software, Firmware and Information integrity
-* 18F will employ integrity verification applications on its information systems to look for evidence of information tampering, errors, and omissions.
-* 18F must employ good software engineering practices with regard to commercial off-the-shelf integrity mechanisms (e.g., parity checks, cyclical redundancy checks, cryptographic hashes).
-* 18F shall use tools to automatically monitor the integrity of the information systems it hosts and incorporate the detection of unauthorized access, system changes, communications or elevation of information system privileges into the organizational incident response capability.
-
-### Spam Protection
-* 18F shall employ spam protection mechanisms at information system entry and exit points on the network to detect and take action on unsolicited messages transported by electronic mail, electronic mail attachments, web accesses, or other common means.
-* 18F should provide the capability to automatically updates spam protection mechanisms (including signature definitions) when new releases are available in accordance with organizational configuration management policy and procedures.
-
-### Information Input Validation
-* 18F shall restrict the information input to the information system to authorized personnel only and check information system inputs (e.g., character set, length, numerical range, acceptable values) for accuracy, completeness and validity.
-
-### Error Handling
-* All information systems must provide the capability to generate error messages that provide information necessary for corrective actions without revealing sensitive or potentially harmful information in error logs and administrative messages that could be exploited by adversaries.
-
-### Information Handling and Retention
-* 18F shall handle and retains both information within and output from its information systems in accordance with organizational policy and operational requirements.
-
-### Memory Protection
-* All information systems must implement forms of data execution prevention and address space layout randomization to protect its memory from unauthorized code execution.
-
-## 4. Roles and Responsibilities
-|Roles                  |Responsibilities
-|-----------------------|---------------------------------------------------------------------------------------------------------|
-|Development Operations | Maintain system integrity and protect all network and application services from potential threats to 18F information systems
-|Security Operations    | Monitors system integrity and threats to all 18F information systems and networks and provide assistance to DevOps for Flaw remediation actions |
-|Senior Director        | Ensuring the Policy is approved, implemented and communicated.|
-|Director of Compliance | Owner of the Policy. Ensuring the Policy meets the compliance requirements.|

--- a/SI-Policy.md
+++ b/SI-Policy.md
@@ -22,6 +22,8 @@ See the **_Applicability_** section of the [GSA IT Security Policy](http://www.g
 
 ## Policy overlay
 
-For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Services's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md). 
+
+## Procedures
 
 


### PR DESCRIPTION
Ensures correct references to pre-existing GSA IT Security Policy, an
easy to read template, and creates sections for procedure enumeration.

Gives literal “new purpose” to each policy - the purposes are both
human readable and aspirational, and not mere restatements of the
control narrative summary from NIST.

This is mildly less DRY at the moment, because I do think it is useful
to see how GSA groups the controls into meta-groups (management,
technical, operational) regardless of what control policy you click
into.