### PR TITLE
Adding procedures for AT and policy for PE

### DIFF
--- a/AT-Policy.md
+++ b/AT-Policy.md
@@ -25,3 +25,11 @@ See the **_Applicability_** section of the [GSA IT Security Policy](http://www.g
 For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
 
 ## Procedures
+
+If cloud.gov staff fail to comply with GSA IT security training requirements, their access to GSA information systems is terminated. This includes access to cloud.gov systems.
+
+See AT-2, AT-2 (2).
+
+The cloud.gov Program Manager ensures that Cloud Operations staff with significant information system security roles complete role-based security-related training at or upon being granted access, and subsequent refresher training at least annually.
+
+Whenever a new person joins the Cloud Operations team, the cloud.gov Program Manager assigns the team member a GitHub issue documenting a checklist of required training materials. The same process is applied to each team member annually as if they were a new team member.See AT-3, AT-4.

--- a/AT-Policy.md
+++ b/AT-Policy.md
@@ -26,10 +26,12 @@ For information on roles and responsibilities, management commitment, coordinati
 
 ## Procedures
 
-If cloud.gov staff fail to comply with GSA IT security training requirements, their access to GSA information systems is terminated. This includes access to cloud.gov systems.
+If cloud.gov staff fail to comply with GSA security training requirements, their access to all GSA information systems is terminated. This includes access to cloud.gov systems.
 
 See AT-2, AT-2 (2).
 
-The cloud.gov Program Manager ensures that Cloud Operations staff with significant information system security roles complete role-based security-related training at or upon being granted access, and subsequent refresher training at least annually.
+The cloud.gov Program Manager ensures that Cloud Operations staff with significant information system security roles complete role-based security-related training upon being granted access, and subsequent refresher training at least annually.
 
-Whenever a new person joins the Cloud Operations team, the cloud.gov Program Manager assigns the team member a GitHub issue documenting a checklist of required training materials. The same process is applied to each team member annually as if they were a new team member.See AT-3, AT-4.
+Whenever a new person joins the Cloud Operations team, the cloud.gov Program Manager assigns the team member a GitHub issue documenting a checklist of required training materials. The same process is applied to each team member annually as if they were a new team member.
+
+See AT-3, AT-4.

--- a/PE-policy.md
+++ b/PE-policy.md
@@ -1,0 +1,29 @@
+# Physical and Environmental Protection
+
+See [CIO P 2100.1J – GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action) Chapter 4, _Policy on Operational Controls_, which covers:
+
+* Awareness and Training (AT)
+* Configuration Management (CM)
+* Contingency Planning (CP)
+* Incident Response (IR)
+* Maintenance (MA)
+* Media Protection (MP)
+* Physical and Environmental Protection (PE)
+* Personnel Security (PS)
+* System and Information Integrity (SI)
+
+## Purpose
+
+Not applicable. cloud.gov is completely virtualized via AWS GovCloud. cloud.gov leverages the Provisional Authorization for AWS GovCloud for all physical and environmental protection.
+
+## Scope
+
+See the **_Applicability_** section of the [GSA IT Security Policy](http://www.gsa.gov/portal/mediaId/129634/fileName/CIO_21001J_CHGE_1_GSA_Information_Technology_(IT)_Security_Policy_(Posted_Version_4-28-2016).action).
+
+## Policy overlay
+
+For information on roles and responsibilities, management commitment, coordination among organizational entities, compliance, reviews, and updates please see the [Technology Transformation Service's (TTS) Common Control Policy](https://github.com/18F/compliance-docs/blob/master/TTS-Common-Control-Policy.md).
+
+## Procedures
+
+Not applicable.


### PR DESCRIPTION
Adding basic procedures for AT based on our current SSP. Also adding a skeleton policy for PE, based on [the MP policy](https://github.com/18F/compliance-docs/blob/atpe/MP-Policy.md), since both are entirely handled by AWS.